### PR TITLE
fix: Update GitHub Actions workflow to use GH_TOKEN for semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Semantic Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           pnpm exec semantic-release
 
@@ -124,4 +124,4 @@ jobs:
         with:
           files: artifacts/**/*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
- Changed the environment variable from GITHUB_TOKEN to GH_TOKEN in the release workflow for semantic release and artifact upload steps, ensuring proper token usage.